### PR TITLE
use python3-onbuild for docker it automatically installs your requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.8-onbuild
 COPY requirements.txt /app/
 RUN pip install --no-cache-dir -U -r /app/requirements.txt
 


### PR DESCRIPTION
I believe it automatically installs it http://docs.docker.oeynet.com/samples/library/python/#pythonwindowsservercore check here for some docs about it i heard some versions of python cant be used with on build or something but python3.8 should work

Anyways, let me know what you think of this