### PR TITLE
Update deploy in docker-compose.yml for avaiblibity on downtime 

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,10 +7,12 @@ services:
     command: bash -c "cd /app && python3 -u bot.py"
     restart: always
     deploy:
+      mode: replicated
+      replicas: 3
       resources:
         limits:
           cpus: "0.50"
-          memory: 50M
+          memory: 50M      
         reservations:
           cpus: "0.25"
           memory: 20M 


### PR DESCRIPTION
Ok, So for deploy in docker-compose you can specify how many containers you want it to run for availability in case 1 goes down right now its set at 3 but you can of course specify more..  this is just easier in case 1 container shuts down it can just automatically refer to the next one instead of it fully restarting then rebooting.. 